### PR TITLE
feat: externalize supabase config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+config.js
+extension/config.js

--- a/build.js
+++ b/build.js
@@ -1,0 +1,15 @@
+const { writeFileSync } = require('fs');
+
+const { SUPABASE_URL, SUPABASE_ANON_KEY } = process.env;
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  throw new Error('SUPABASE_URL and SUPABASE_ANON_KEY must be set');
+}
+
+const content = [
+  `export const SUPABASE_URL = '${SUPABASE_URL}';`,
+  `export const SUPABASE_ANON_KEY = '${SUPABASE_ANON_KEY}';`,
+  ''
+].join('\n');
+
+writeFileSync('config.js', content);
+writeFileSync('extension/config.js', content);

--- a/config.example.js
+++ b/config.example.js
@@ -1,0 +1,2 @@
+export const SUPABASE_URL = 'https://your-project.supabase.co';
+export const SUPABASE_ANON_KEY = 'public-anon-key';

--- a/extension/background.js
+++ b/extension/background.js
@@ -1,5 +1,4 @@
-const SUPABASE_URL = 'https://your-project.supabase.co';
-const SUPABASE_ANON_KEY = 'public-anon-key';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js';
 
 browser.runtime.onInstalled.addListener(() => {
   browser.contextMenus.create({

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,8 @@
   "description": "Save bookmarks to Supabase",
   "permissions": ["contextMenus", "activeTab"],
   "background": {
-    "service_worker": "background.js"
+    "service_worker": "background.js",
+    "type": "module"
   },
   "action": {
     "default_title": "Save page to Savey"

--- a/index.html
+++ b/index.html
@@ -13,31 +13,29 @@
     <input type="text" id="title" placeholder="Title" />
     <button type="submit">Save</button>
   </form>
-  <script type="module">
-    import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+    <script type="module">
+      import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+      import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js';
 
-    const SUPABASE_URL = 'https://your-project.supabase.co';
-    const SUPABASE_ANON_KEY = 'public-anon-key';
+      const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
 
-    const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+      const form = document.getElementById('bookmark-form');
+      form.addEventListener('submit', async (e) => {
+        e.preventDefault();
+        const url = document.getElementById('url').value;
+        const title = document.getElementById('title').value;
+        const { error } = await supabase.from('bookmarks').insert({ url, title });
+        if (error) {
+          alert('Error saving bookmark: ' + error.message);
+        } else {
+          form.reset();
+          alert('Saved!');
+        }
+      });
 
-    const form = document.getElementById('bookmark-form');
-    form.addEventListener('submit', async (e) => {
-      e.preventDefault();
-      const url = document.getElementById('url').value;
-      const title = document.getElementById('title').value;
-      const { error } = await supabase.from('bookmarks').insert({ url, title });
-      if (error) {
-        alert('Error saving bookmark: ' + error.message);
-      } else {
-        form.reset();
-        alert('Saved!');
+      if ('serviceWorker' in navigator) {
+        navigator.serviceWorker.register('/sw.js', { type: 'module' });
       }
-    });
-
-    if ('serviceWorker' in navigator) {
-      navigator.serviceWorker.register('/sw.js');
-    }
-  </script>
-</body>
+    </script>
+  </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "test": "echo 'No tests'"
+    "test": "echo 'No tests'",
+    "build": "node build.js"
   }
 }

--- a/sw.js
+++ b/sw.js
@@ -1,5 +1,4 @@
-const SUPABASE_URL = 'https://your-project.supabase.co';
-const SUPABASE_ANON_KEY = 'public-anon-key';
+import { SUPABASE_URL, SUPABASE_ANON_KEY } from './config.js';
 
 self.addEventListener('install', () => self.skipWaiting());
 self.addEventListener('activate', (event) => event.waitUntil(self.clients.claim()));


### PR DESCRIPTION
## Summary
- load Supabase credentials from generated config.js
- use shared config in web app, service worker and browser extension
- add build step to generate config from environment variables

## Testing
- `npm test`
- `SUPABASE_URL=https://example.supabase.co SUPABASE_ANON_KEY=anon npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c816b4d7e0832097b0d7e12df5b0e7